### PR TITLE
Refs #5. Added testcases with @mixin

### DIFF
--- a/sampleprojects/sampleproject/MixinInheritingImported.js
+++ b/sampleprojects/sampleproject/MixinInheritingImported.js
@@ -1,0 +1,27 @@
+/** @module sampleproject/MixinInheritingImported */
+define([
+	"dcl/dcl",
+	"sampleframework/Base0",
+	"sampleframework/Base1"
+], function (dcl, Base0, Base1) {
+	/**
+	 * Sample widget class.
+	 * @class module:sampleproject/MixinInheritingImported
+	 * @mixin
+	 * @augments {module:sampleframework/Base0}
+	 * @augments {module:sampleframework/Base1}
+	 */
+	var MixinInheritingImported = dcl([Base0, Base1], /** @lends module:sampleproject/MixinInheritingImported# */ {
+		/**
+		 * Description
+		 * for {@link module:sampleproject/MixinInheritingImported#createdCallback sampleproject/MixinInheritingImported#createdCallback}.
+		 * @method
+		 */
+		createdCallback: dcl.before(function () {
+			console.log("module:sampleproject/MixinInheritingImported#createdCallback called.");
+		})
+	});
+
+	// Doing return dcl() prevents JSDoc from generating doclets for prototype methods/properties
+	return MixinInheritingImported;
+});

--- a/sampleprojects/sampleproject/MixinInheritingInHouse.js
+++ b/sampleprojects/sampleproject/MixinInheritingInHouse.js
@@ -1,0 +1,27 @@
+/** @module sampleproject/MixinInheritingInHouse */
+define([
+	"dcl/dcl",
+	"./Base0",
+	"./Base1"
+], function (dcl, Base0, Base1) {
+	/**
+	 * Sample widget class.
+	 * @class module:sampleproject/MixinInheritingInHouse
+	 * @mixin
+	 * @augments {module:sampleproject/Base0}
+	 * @augments {module:sampleproject/Base1}
+	 */
+	var MixinInheritingInHouse = dcl([Base0, Base1], /** @lends module:sampleproject/MixinInheritingInHouse# */ {
+		/**
+		 * Description
+		 * for {@link module:sampleproject/MixinInheritingInHouse#createdCallback sampleproject/MixinInheritingInHouse#createdCallback}.
+		 * @method
+		 */
+		createdCallback: dcl.before(function () {
+			console.log("module:sampleproject/MixinInheritingInHouse#createdCallback called.");
+		})
+	});
+
+	// Doing return dcl() prevents JSDoc from generating doclets for prototype methods/properties
+	return MixinInheritingInHouse;
+});


### PR DESCRIPTION
This shows that with the amddcl template just as with the default template the inherited APIs (both "in house" and "imported") are not shown for modules marked @mixin.
