### PR TITLE
Fix missing double-quote after module name in generated code example

### DIFF
--- a/templates/amddcl/publish.js
+++ b/templates/amddcl/publish.js
@@ -174,7 +174,7 @@ function attachModuleSymbols(doclets, modules) {
             var name = module.module.name.replace(/^module:/, ''),
                 index = name.lastIndexOf('/');
             module.module.name = name.substr(index >= 0 ? (index + 1) : 0);
-            module.module.amdSyntax = 'require(["' + name + '], function (' +
+            module.module.amdSyntax = 'require(["' + name + '"], function (' +
                 module.module.name + ') { <br/>&nbsp;&nbsp;$1;<br/> });';
         }
     });


### PR DESCRIPTION
This is a tiny fix for this issue:

![image](https://cloud.githubusercontent.com/assets/1583981/3056521/86406370-e1cb-11e3-8fda-3a9a6776bcce.png)
