### PR TITLE
Added examples for modules with static utilities and for static functions in dcl classes

### DIFF
--- a/sampleprojects/sampleframework/Base0.js
+++ b/sampleprojects/sampleframework/Base0.js
@@ -27,6 +27,18 @@ define(["dcl/dcl"], function (dcl) {
 			console.log("module:sampleframework/Base0#methodOfBase0 called.");
 		}
 	});
+	
+	/**
+	 * Description of a static method.
+	 * @function aStaticMethod
+	 * @memberOf module:sampleframework/Base0
+	 * @param {string} a Description of the parameter a.
+	 * @param {string} b Description of the parameter b.
+	 * @returns {string} Description of the return type.
+	 */
+	Base0.aStaticMethod = function (a, b) {
+		return a + b;
+	};
 
 	// Doing return dcl() prevents JSDoc from generating doclets for prototype methods/properties
 	return Base0;

--- a/sampleprojects/sampleframework/utils.js
+++ b/sampleprojects/sampleframework/utils.js
@@ -1,0 +1,24 @@
+/** @module sampleframework/utils */
+define([], function () {
+	
+	/**
+	 * This is a module containing static utility functions.
+	 * @example
+	 * require["sampleframework/utils"], function(utils) {
+	 *   utils.method1();
+	 * };
+	 */
+	return /** @lends module:sampleframework/utils */ {
+		
+		/**
+		 * Description of a static function.
+		 * @param {string} a Description of the parameter a.
+		 * @param {string} b Description of the parameter b.
+		 * @returns {string} Description of the return type.
+		 */
+		method1: function (a, b) {
+			return a + b;
+		}
+	};
+});
+


### PR DESCRIPTION
The purpose of the added code in the sampleproject is to serve for testing the patterns for the jsdoc comments for the corresponding cases. As of today, jsdoc-amddcl produces the expected output for it.
