### PR TITLE
Make deduper plugin ignore undocumented doclet.

### DIFF
--- a/custom-plugins/dedupe.js
+++ b/custom-plugins/dedupe.js
@@ -3,7 +3,7 @@
 exports.handlers = {
     processingComplete: function(e) {
         for (var table = {}, doclets = e.doclets, i = doclets.length - 1; i >= 0; --i) {
-            if (doclets[i].memberof) {
+            if (doclets[i].memberof && !doclets[i].undocumented) {
                 if (table[doclets[i].longname]) {
                     doclets.splice(i, 1);
                 } else {


### PR DESCRIPTION
Issue found in: https://github.com/ibm-js/deliteful/pull/142
