### PR TITLE
Make module doc path based on module path.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,7 +13,8 @@ module.exports = function (grunt) {
 							"./sampleprojects/sampleframework",
 							"./sampleprojects/sampleframework/README.md",
 							"./sampleprojects/sampleframework/package.json"
-						]
+						],
+						packagePathFormat: "${name}/docs/api/${version}"
 					},
 					{
 						args: [
@@ -42,9 +43,13 @@ module.exports = function (grunt) {
 							"./sampleprojects/sampleproject/README.md",
 							"./sampleprojects/sampleproject/package.json"
 						],
+						paths: {
+							"sampleframework": "../../../../sampleframework/docs/api/0.1.0-dev/sampleframework"
+						},
 						imports: [
 							"./out/sampleframework"
-						]
+						],
+						packagePathFormat: "${name}/docs/api/${version}"
 					},
 					{
 						args: [
@@ -58,6 +63,43 @@ module.exports = function (grunt) {
 							"./sampleprojects/sampleproject/package.json"
 						],
 						dest: "./out/sampleproject/doclets.json"
+					}
+				]
+			},
+
+			"sampleprojectchild": {
+				files: [
+					{
+						args: [
+							"-c",
+							"./conf.json"
+						],
+						src: [
+							"./sampleprojects/sampleprojectchild",
+							"./sampleprojects/sampleprojectchild/README.md",
+							"./sampleprojects/sampleprojectchild/package.json"
+						],
+						paths: {
+							"sampleframework": "../../../../sampleframework/docs/api/0.1.0-dev/sampleframework",
+							"sampleproject": "../../../../sampleproject/docs/api/0.1.0-dev/sampleproject"
+						},
+						imports: [
+							"./out/sampleproject"
+						],
+						packagePathFormat: "${name}/docs/api/${version}"
+					},
+					{
+						args: [
+							"-X",
+							"-c",
+							"./conf.json"
+						],
+						src: [
+							"./sampleprojects/sampleprojectchild",
+							"./sampleprojects/sampleprojectchild/README.md",
+							"./sampleprojects/sampleprojectchild/package.json"
+						],
+						dest: "./out/sampleprojectchild/doclets.json"
 					}
 				]
 			}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
 	"version": "0.1.0-dev",
 	"dependencies": {
 		"jsdoc": "https://github.com/jsdoc3/jsdoc/archive/v3.3.0-alpha7.tar.gz",
-		"taffydb": "https://github.com/hegemonic/taffydb/tarball/master"
+		"taffydb": "https://github.com/hegemonic/taffydb/tarball/master",
+		"catharsis": "~0.7.1"
 	},
 	"devDependencies": {
 		"grunt": "~0.4.0"

--- a/sampleprojects/sampleprojectchild/Base0.js
+++ b/sampleprojects/sampleprojectchild/Base0.js
@@ -1,0 +1,30 @@
+/** @module sampleprojectchild/Base0 */
+define(["dcl/dcl"], function (dcl) {
+	/**
+	 * A sample base widget class.
+	 * @class module:sampleprojectchild/Base0
+	 */
+	return dcl(null, /** @lends module:sampleprojectchild/Base0# */ {
+		/**
+		 * Description for {@link module:sampleprojectchild/Base0#createdCallback sampleprojectchild/Base0#createdCallback}.
+		 * @method
+		 */
+		createdCallback: dcl.before(function () {
+			console.log("module:sampleprojectchild/Base0#createdCallback called.");
+		}),
+
+		/**
+		 * Description for {@link module:sampleprojectchild/Base0#methodOfBaseCommon sampleprojectchild/Base0#methodOfBaseCommon}.
+		 */
+		methodOfBaseCommon: function () {
+			console.log("module:sampleprojectchild/Base0#methodOfBaseCommon called.");
+		},
+
+		/**
+		 * Description for {@link module:sampleprojectchild/Base0#methodOfBase0 sampleprojectchild/Base0#methodOfBase0}.
+		 */
+		methodOfBase0: function () {
+			console.log("module:sampleprojectchild/Base0#methodOfBase0 called.");
+		}
+	});
+});

--- a/sampleprojects/sampleprojectchild/Base1.js
+++ b/sampleprojects/sampleprojectchild/Base1.js
@@ -1,0 +1,30 @@
+/** @module sampleprojectchild/Base1 */
+define(["dcl/dcl"], function (dcl) {
+	/**
+	 * Another sample base widget class.
+	 * @class module:sampleprojectchild/Base1
+	 */
+	return dcl(null, /** @lends module:sampleprojectchild/Base1# */ {
+		/**
+		 * Description for {@link module:sampleprojectchild/Base1#createdCallback sampleprojectchild/Base1#createdCallback}.
+		 * @method
+		 */
+		createdCallback: dcl.before(function () {
+			console.log("module:sampleprojectchild/Base1#createdCallback called.");
+		}),
+
+		/**
+		 * Description for {@link module:sampleprojectchild/Base1#methodOfBaseCommon sampleprojectchild/Base1#methodOfBaseCommon}.
+		 */
+		methodOfBaseCommon: function () {
+			console.log("module:sampleprojectchild/Base1#methodOfBaseCommon called.");
+		},
+
+		/**
+		 * Description for {@link module:sampleprojectchild/Base1#methodOfBase1 sampleprojectchild/Base1#methodOfBase1}.
+		 */
+		methodOfBase1: function () {
+			console.log("module:sampleprojectchild/Base1#methodOfBase1 called.");
+		}
+	});
+});

--- a/sampleprojects/sampleprojectchild/MixinInheritingImported.js
+++ b/sampleprojects/sampleprojectchild/MixinInheritingImported.js
@@ -1,0 +1,24 @@
+/** @module sampleprojectchild/MixinInheritingImported */
+define([
+	"dcl/dcl",
+	"sampleframework/Base0",
+	"sampleproject/Base1"
+], function (dcl, Base0, Base1) {
+	/**
+	 * Sample widget class.
+	 * @class module:sampleprojectchild/MixinInheritingImported
+	 * @mixin
+	 * @augments {module:sampleframework/Base0}
+	 * @augments {module:sampleproject/Base1}
+	 */
+	return dcl([Base0, Base1], /** @lends module:sampleprojectchild/MixinInheritingImported# */ {
+		/**
+		 * Description
+		 * for {@link module:sampleprojectchild/MixinInheritingImported#createdCallback sampleprojectchild/MixinInheritingImported#createdCallback}.
+		 * @method
+		 */
+		createdCallback: dcl.before(function () {
+			console.log("module:sampleprojectchild/MixinInheritingImported#createdCallback called.");
+		})
+	});
+});

--- a/sampleprojects/sampleprojectchild/MixinInheritingInHouse.js
+++ b/sampleprojects/sampleprojectchild/MixinInheritingInHouse.js
@@ -1,0 +1,24 @@
+/** @module sampleprojectchild/MixinInheritingInHouse */
+define([
+	"dcl/dcl",
+	"./Base0",
+	"./Base1"
+], function (dcl, Base0, Base1) {
+	/**
+	 * Sample widget class.
+	 * @class module:sampleprojectchild/MixinInheritingInHouse
+	 * @mixin
+	 * @augments {module:sampleprojectchild/Base0}
+	 * @augments {module:sampleprojectchild/Base1}
+	 */
+	return dcl([Base0, Base1], /** @lends module:sampleprojectchild/MixinInheritingInHouse# */ {
+		/**
+		 * Description
+		 * for {@link module:sampleprojectchild/MixinInheritingInHouse#createdCallback sampleprojectchild/MixinInheritingInHouse#createdCallback}.
+		 * @method
+		 */
+		createdCallback: dcl.before(function () {
+			console.log("module:sampleprojectchild/MixinInheritingInHouse#createdCallback called.");
+		})
+	});
+});

--- a/sampleprojects/sampleprojectchild/README.md
+++ b/sampleprojects/sampleprojectchild/README.md
@@ -1,0 +1,3 @@
+# sampleprojectchild
+
+This repositry is a sample project to test https://github.com/ibm-js/jsdoc-amddcl/.

--- a/sampleprojects/sampleprojectchild/WidgetInheritingImported.js
+++ b/sampleprojects/sampleprojectchild/WidgetInheritingImported.js
@@ -1,0 +1,23 @@
+/** @module sampleprojectchild/WidgetInheritingImported */
+define([
+	"dcl/dcl",
+	"sampleframework/Base0",
+	"sampleproject/Base1"
+], function (dcl, Base0, Base1) {
+	/**
+	 * Sample widget class.
+	 * @class module:sampleprojectchild/WidgetInheritingImported
+	 * @augments {module:sampleframework/Base0}
+	 * @augments {module:sampleproject/Base1}
+	 */
+	return dcl([Base0, Base1], /** @lends module:sampleprojectchild/WidgetInheritingImported# */ {
+		/**
+		 * Description
+		 * for {@link module:sampleprojectchild/WidgetInheritingImported#createdCallback sampleprojectchild/WidgetInheritingImported#createdCallback}.
+		 * @method
+		 */
+		createdCallback: dcl.before(function () {
+			console.log("module:sampleprojectchild/WidgetInheritingImported#createdCallback called.");
+		})
+	});
+});

--- a/sampleprojects/sampleprojectchild/WidgetInheritingInHouse.js
+++ b/sampleprojects/sampleprojectchild/WidgetInheritingInHouse.js
@@ -1,0 +1,23 @@
+/** @module sampleprojectchild/WidgetInheritingInHouse */
+define([
+	"dcl/dcl",
+	"./Base0",
+	"./Base1"
+], function (dcl, Base0, Base1) {
+	/**
+	 * Sample widget class.
+	 * @class module:sampleprojectchild/WidgetInheritingInHouse
+	 * @augments {module:sampleprojectchild/Base0}
+	 * @augments {module:sampleprojectchild/Base1}
+	 */
+	return dcl([Base0, Base1], /** @lends module:sampleprojectchild/WidgetInheritingInHouse# */ {
+		/**
+		 * Description
+		 * for {@link module:sampleprojectchild/WidgetInheritingInHouse#createdCallback sampleprojectchild/WidgetInheritingInHouse#createdCallback}.
+		 * @method
+		 */
+		createdCallback: dcl.before(function () {
+			console.log("module:sampleprojectchild/WidgetInheritingInHouse#createdCallback called.");
+		})
+	});
+});

--- a/sampleprojects/sampleprojectchild/package.json
+++ b/sampleprojects/sampleprojectchild/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "sampleprojectchild",
+	"version": "0.1.0-dev",
+	"dependencies": {
+		"sampleframework": "*",
+		"sampleproject": "*"
+	},
+	"devDependencies": {
+	},
+	"licenses": [
+		{
+			"type": "BSD",
+			"url": "https://github.com/ibm-js/jsdoc-amddcl/blob/master/LICENSE"
+		}
+	],
+	"bugs": "https://github.com/ibm-js/jsdoc-amddcl/issues"
+}

--- a/tasks/jsdoc.js
+++ b/tasks/jsdoc.js
@@ -10,8 +10,14 @@ module.exports = function (grunt) {
 			file.dest && grunt.file.mkdir(path.dirname(file.dest));
 		});
 		grunt.util.async.forEach(this.files, function (file, callback) {
+			if (file.paths) {
+				process.env.JSDOC_MODULE_PATHS = JSON.stringify(file.paths);
+			}
 			if (file.imports) {
 				process.env.JSDOC_IMPORT_ROOTS = file.imports.join(path.delimiter);
+			}
+			if (file.packagePathFormat) {
+				process.env.JSDOC_PACKAGE_PATH_FORMAT = file.packagePathFormat;
 			}
 			var args = [
 				JSON.stringify(path.resolve(path.dirname(module.filename), "../node_modules/jsdoc/jsdoc.js")),
@@ -29,6 +35,7 @@ module.exports = function (grunt) {
 			exec(command, function (err, stdout, stderr) {
 				stdout && grunt.log.writeln(stdout);
 				stderr && grunt.log.error(stderr);
+				delete process.env.JSDOC_MODULE_PATHS;
 				delete process.env.JSDOC_IMPORT_ROOTS;
 				if (err) {
 					grunt.log.error(err);

--- a/templates/amddcl/templateHelper.js
+++ b/templates/amddcl/templateHelper.js
@@ -1,0 +1,786 @@
+/*global env: true */
+/**
+ * @module jsdoc/util/templateHelper
+ */
+'use strict';
+
+var dictionary = require('jsdoc/tag/dictionary');
+var util = require('util');
+var path = require('jsdoc/path');
+
+var hasOwnProp = Object.prototype.hasOwnProperty;
+
+var files = {};
+
+// each container gets its own html file
+var containers = ['class', 'module', 'external', 'namespace', 'mixin'];
+
+var tutorials;
+
+/** Sets tutorials map.
+    @param {jsdoc.tutorial.Tutorial} root - Root tutorial node.
+ */
+exports.setTutorials = function(root) {
+    tutorials = root;
+};
+
+exports.globalName = 'global';
+exports.fileExtension = '.html';
+exports.scopeToPunc = require('jsdoc/name').scopeToPunc;
+
+function getNamespace(kind) {
+    if (dictionary.isNamespace(kind)) {
+        return kind + ':';
+    }
+    return '';
+}
+
+function makeFilenameUnique(filename, str) {
+    var key = filename.toLowerCase();
+    var nonUnique = true;
+
+    // append enough underscores to make the filename unique
+    while (nonUnique) {
+        if ( files[key] && hasOwnProp.call(files, key) ) {
+            filename += '_';
+            key = filename.toLowerCase();
+        } else {
+            nonUnique = false;
+        }
+    }
+
+    files[key] = str;
+    return filename;
+}
+
+function cleanseFilename(str) {
+    str = str || '';
+
+    // allow for namespace prefix
+    // TODO: use prefixes in jsdoc/doclet
+    return str.replace(/^(event|module|external|package):/, '$1-')
+        // use - instead of ~ to denote 'inner'
+        .replace(/~/g, '-')
+        // use _ instead of # to denote 'instance'
+        .replace(/\#/g, '_')
+        // remove the variation, if any
+        .replace(/\([\s\S]*\)$/, '');
+}
+
+var htmlsafe = exports.htmlsafe = function(str) {
+    return str.replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;');
+};
+
+/**
+ * Convert a string to a unique filename, including an extension.
+ *
+ * Filenames are cached to ensure that they are used only once. For example, if the same string is
+ * passed in twice, two different filenames will be returned.
+ *
+ * Also, filenames are not considered unique if they are capitalized differently but are otherwise
+ * identical.
+ * @param {string} str The string to convert.
+ * @return {string} The filename to use for the string.
+ */
+var getUniqueFilename = exports.getUniqueFilename = function(str) {
+    var module = (/^module:(.*)$/.exec(str) || [])[1];
+    if (module) {
+        var paths,
+            resolved = module;
+        try {
+            paths = getUniqueFilename.paths = getUniqueFilename.paths || JSON.parse(process.env.JSDOC_MODULE_PATHS);
+        } catch (e) {}
+        for (var namespace in paths) {
+            var parts = module.split('/');
+            for (var i = 1; i < parts.length; i++) {
+                if (parts.slice(0, i).join('/') === namespace) {
+                    resolved = paths[namespace] + '/' + parts.slice(i).join('/');
+                    break;
+                }
+            }
+        }
+        return resolved + exports.fileExtension;
+    }
+
+    // allow for namespace prefix
+    var basename = cleanseFilename(str);
+
+    // if the basename includes characters that we can't use in a filepath, remove everything up to
+    // and including the last bad character
+    var regexp = /[^$a-z0-9._\-](?=[$a-z0-9._\-]*$)/i;
+    var result = regexp.exec(basename);
+    if (result && result.index) {
+        basename = basename.substr(result.index + 1);
+    }
+
+    // make sure we don't create hidden files on POSIX systems
+    basename = basename.replace(/^\./, '');
+    // and in case we've now stripped the entire basename (uncommon, but possible):
+    basename = basename.length ? basename : '_';
+
+    return makeFilenameUnique(basename, str) + exports.fileExtension;
+};
+
+// two-way lookup
+var linkMap = {
+    longnameToUrl: {},
+    urlToLongname: {}
+};
+
+var tutorialLinkMap = {
+    nameToUrl: {},
+    urlToName: {}
+};
+
+var longnameToUrl = exports.longnameToUrl = linkMap.longnameToUrl;
+
+function parseType(longname) {
+    var catharsis = require('catharsis');
+    var err;
+
+    try {
+        return catharsis.parse(longname, {jsdoc: true});
+    }
+    catch (e) {
+        err = new Error('unable to parse ' + longname + ': ' + e.message);
+        require('jsdoc/util/logger').error(err);
+        return longname;
+    }
+}
+
+function stringifyType(parsedType, cssClass, linkMap) {
+    return require('catharsis').stringify(parsedType, {
+        cssClass: cssClass,
+        htmlSafe: true,
+        links: linkMap
+    });
+}
+
+function hasUrlPrefix(text) {
+    return (/^(http|ftp)s?:\/\//).test(text);
+}
+
+/**
+ * Build an HTML link to the symbol with the specified longname. If the longname is not
+ * associated with a URL, this method simply returns the link text, if provided, or the longname.
+ *
+ * The `longname` parameter can also contain a URL rather than a symbol's longname.
+ *
+ * This method supports type applications that can contain one or more types, such as
+ * `Array.<MyClass>` or `Array.<(MyClass|YourClass)>`. In these examples, the method attempts to
+ * replace `Array`, `MyClass`, and `YourClass` with links to the appropriate types. The link text
+ * is ignored for type applications.
+ *
+ * @param {string} longname - The longname (or URL) that is the target of the link.
+ * @param {string=} linkText - The text to display for the link, or `longname` if no text is
+ * provided.
+ * @param {Object} options - Options for building the link.
+ * @param {string=} options.cssClass - The CSS class (or classes) to include in the link's `<a>`
+ * tag.
+ * @param {string=} options.fragmentId - The fragment identifier (for example, `name` in
+ * `foo.html#name`) to append to the link target.
+ * @param {string=} options.linkMap - The link map in which to look up the longname.
+ * @param {boolean=} options.monospace - Indicates whether to display the link text in a monospace
+ * font.
+ * @return {string} The HTML link, or the link text if the link is not available.
+ */
+function buildLink(longname, linkText, options) {
+    var catharsis = require('catharsis');
+
+    var classString = options.cssClass ? util.format(' class="%s"', options.cssClass) : '';
+    var fragmentString = options.fragmentId ? '#' + options.fragmentId : '';
+    var stripped;
+    var text;
+    var url;
+    var parsedType;
+
+    // handle cases like:
+    // @see <http://example.org>
+    // @see http://example.org
+    stripped = longname ? longname.replace(/^<|>$/g, '') : '';
+    var urlPrefixed = hasUrlPrefix(stripped);
+    if (urlPrefixed) {
+        url = stripped;
+        text = linkText || stripped;
+    }
+    // handle complex type expressions that may require multiple links
+    // (but skip anything that looks like an inline tag)
+    else if (longname && longname.search(/[<{(]/) !== -1 && /\{\@.+\}/.test(longname) === false) {
+        parsedType = parseType(longname);
+        return stringifyType(parsedType, options.cssClass, options.linkMap);
+    }
+    else {
+        url = hasOwnProp.call(options.linkMap, longname) ? options.linkMap[longname] : '';
+        text = linkText || longname;
+    }
+
+    text = options.monospace ? '<code>' + text + '</code>' : text;
+
+    if (!url) {
+        return text;
+    }
+    else {
+        return util.format('<a href="%s%s%s"%s>%s</a>', !urlPrefixed && options.prefix || '', url, fragmentString, classString, text);
+    }
+}
+
+/**
+ * Retrieve an HTML link to the symbol with the specified longname. If the longname is not
+ * associated with a URL, this method simply returns the link text, if provided, or the longname.
+ *
+ * The `longname` parameter can also contain a URL rather than a symbol's longname.
+ *
+ * This method supports type applications that can contain one or more types, such as
+ * `Array.<MyClass>` or `Array.<(MyClass|YourClass)>`. In these examples, the method attempts to
+ * replace `Array`, `MyClass`, and `YourClass` with links to the appropriate types. The link text
+ * is ignored for type applications.
+ *
+ * @param {string} longname - The longname (or URL) that is the target of the link.
+ * @param {string=} linkText - The text to display for the link, or `longname` if no text is
+ * provided.
+ * @param {string=} cssClass - The CSS class (or classes) to include in the link's `<a>` tag.
+ * @param {string=} fragmentId - The fragment identifier (for example, `name` in `foo.html#name`) to
+ * append to the link target.
+ * @param {string=} prefix The prefix to prepend to the link.
+ * @return {string} The HTML link, or a plain-text string if the link is not available.
+ */
+var linkto = exports.linkto = function(longname, linkText, cssClass, fragmentId, prefix) {
+    return buildLink(longname, linkText, {
+        cssClass: cssClass,
+        fragmentId: fragmentId,
+        linkMap: longnameToUrl,
+        prefix: prefix
+    });
+};
+
+function useMonospace(tag, text) {
+    var cleverLinks;
+    var monospaceLinks;
+    var result;
+
+    if ( hasUrlPrefix(text) ) {
+        result = false;
+    }
+    else if (tag === 'linkplain') {
+        result = false;
+    }
+    else if (tag === 'linkcode') {
+        result = true;
+    }
+    else {
+        cleverLinks = env.conf.templates.cleverLinks;
+        monospaceLinks = env.conf.templates.monospaceLinks;
+
+        if (monospaceLinks || cleverLinks) {
+            result = true;
+        }
+    }
+
+    return result || false;
+}
+
+function splitLinkText(text) {
+    var linkText;
+    var target;
+    var splitIndex;
+
+    // if a pipe is not present, we split on the first space
+    splitIndex = text.indexOf('|');
+    if (splitIndex === -1) {
+        splitIndex = text.search(/\s/);
+    }
+
+    if (splitIndex !== -1) {
+        linkText = text.substr(splitIndex + 1);
+        // Normalize subsequent newlines to a single space.
+        linkText = linkText.replace(/\n+/, ' ');
+        target = text.substr(0, splitIndex);
+    }
+
+    return {
+        linkText: linkText,
+        target: target || text
+    };
+}
+
+var tutorialToUrl = exports.tutorialToUrl = function(tutorial) {
+    var node = tutorials.getByName(tutorial);
+    // no such tutorial
+    if (!node) {
+        require('jsdoc/util/logger').error( new Error('No such tutorial: ' + tutorial) );
+        return null;
+    }
+
+    var url;
+    // define the URL if necessary
+    if (!hasOwnProp.call(tutorialLinkMap.nameToUrl, node.name)) {
+        url = 'tutorial-' + getUniqueFilename(node.name);
+        tutorialLinkMap.nameToUrl[node.name] = url;
+        tutorialLinkMap.urlToName[url] = node.name;
+    }
+
+    return tutorialLinkMap.nameToUrl[node.name];
+};
+
+/**
+ * Retrieve a link to a tutorial, or the name of the tutorial if the tutorial is missing. If the
+ * `missingOpts` parameter is supplied, the names of missing tutorials will be prefixed by the
+ * specified text and wrapped in the specified HTML tag and CSS class.
+ *
+ * @todo Deprecate missingOpts once we have a better error-reporting mechanism.
+ * @param {string} tutorial The name of the tutorial.
+ * @param {string} content The link text to use.
+ * @param {object} [missingOpts] Options for displaying the name of a missing tutorial.
+ * @param {string} missingOpts.classname The CSS class to wrap around the tutorial name.
+ * @param {string} missingOpts.prefix The prefix to add to the tutorial name.
+ * @param {string} missingOpts.tag The tag to wrap around the tutorial name.
+ * @return {string} An HTML link to the tutorial, or the name of the tutorial with the specified
+ * options.
+ */
+var toTutorial = exports.toTutorial = function(tutorial, content, missingOpts) {
+    if (!tutorial) {
+        require('jsdoc/util/logger').error( new Error('Missing required parameter: tutorial') );
+        return null;
+    }
+
+    var node = tutorials.getByName(tutorial);
+    // no such tutorial
+    if (!node) {
+        missingOpts = missingOpts || {};
+        var tag = missingOpts.tag;
+        var classname = missingOpts.classname;
+
+        var link = tutorial;
+        if (missingOpts.prefix) {
+            link = missingOpts.prefix + link;
+        }
+        if (tag) {
+            link = '<' + tag + (classname ? (' class="' + classname + '">') : '>') + link;
+            link += '</' + tag + '>';
+        }
+        return link;
+    }
+
+    content = content || node.title;
+
+    return '<a href="' + tutorialToUrl(tutorial) + '">' + content + '</a>';
+};
+
+/** Find symbol {@link ...} and {@tutorial ...} strings in text and turn into html links */
+exports.resolveLinks = function(str, prefix) {
+    var replaceInlineTags = require('jsdoc/tag/inline').replaceInlineTags;
+
+    function extractLeadingText(string, completeTag) {
+        var tagIndex = string.indexOf(completeTag);
+        var leadingText = null;
+        var leadingTextRegExp = /\[(.+?)\]/g;
+        var leadingTextInfo = leadingTextRegExp.exec(string);
+
+        // did we find leading text, and if so, does it immediately precede the tag?
+        while (leadingTextInfo && leadingTextInfo.length) {
+            if (leadingTextInfo.index + leadingTextInfo[0].length === tagIndex) {
+                string = string.replace(leadingTextInfo[0], '');
+                leadingText = leadingTextInfo[1];
+                break;
+            }
+
+            leadingTextInfo = leadingTextRegExp.exec(string);
+        }
+
+        return {
+            leadingText: leadingText,
+            string: string
+        };
+    }
+
+    function processLink(string, tagInfo) {
+        var leading = extractLeadingText(string, tagInfo.completeTag);
+        var linkText = leading.leadingText;
+        var monospace;
+        var split;
+        var target;
+        string = leading.string;
+
+        split = splitLinkText(tagInfo.text);
+        target = split.target;
+        linkText = linkText || split.linkText;
+
+        monospace = useMonospace(tagInfo.tag, tagInfo.text);
+
+        return string.replace( tagInfo.completeTag, buildLink(target, linkText, {
+            linkMap: longnameToUrl,
+            monospace: monospace,
+            prefix: prefix
+        }) );
+    }
+
+    function processTutorial(string, tagInfo) {
+        var leading = extractLeadingText(string, tagInfo.completeTag);
+        string = leading.string;
+
+        return string.replace( tagInfo.completeTag, toTutorial(tagInfo.text, leading.leadingText) );
+    }
+
+    var replacers = {
+        link: processLink,
+        linkcode: processLink,
+        linkplain: processLink,
+        tutorial: processTutorial
+    };
+
+    return replaceInlineTags(str, replacers).newString;
+};
+
+/** Convert tag text like "Jane Doe <jdoe@example.org>" into a mailto link */
+exports.resolveAuthorLinks = function(str) {
+    var author;
+    var matches = str.match(/^\s?([\s\S]+)\b\s+<(\S+@\S+)>\s?$/);
+    if (matches && matches.length === 3) {
+        author = '<a href="mailto:' + matches[2] + '">' + htmlsafe(matches[1]) + '</a>';
+    }
+    else {
+        author = htmlsafe(str);
+    }
+
+    return author;
+};
+
+/**
+ * Find items in a TaffyDB database that match the specified key-value pairs.
+ * @param {TAFFY} data The TaffyDB database to search.
+ * @param {object|function} spec Key-value pairs to match against (for example,
+ * `{ longname: 'foo' }`), or a function that returns `true` if a value matches or `false` if it
+ * does not match.
+ * @return {array<object>} The matching items.
+ */
+var find = exports.find = function(data, spec) {
+    return data(spec).get();
+};
+
+/**
+ * Check whether a symbol is a function and is the only symbol exported by a module (as in
+ * `module.exports = function() {};`).
+ *
+ * @private
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet for the symbol.
+ * @return {boolean} `true` if the symbol is a function and is the only symbol exported by a module;
+ * otherwise, `false`.
+ */
+function isModuleFunction(doclet) {
+    var MODULE_PREFIX = require('jsdoc/name').MODULE_PREFIX;
+
+    return doclet.longname && doclet.longname === doclet.name &&
+        doclet.longname.indexOf(MODULE_PREFIX) === 0 && doclet.kind === 'function';
+}
+
+/**
+ * Retrieve all of the following types of members from a set of doclets:
+ *
+ * + Classes
+ * + Externals
+ * + Globals
+ * + Mixins
+ * + Modules
+ * + Namespaces
+ * + Events
+ * @param {TAFFY} data The TaffyDB database to search.
+ * @return {object} An object with `classes`, `externals`, `globals`, `mixins`, `modules`,
+ * `events`, and `namespaces` properties. Each property contains an array of objects.
+ */
+exports.getMembers = function(data) {
+    var members = {
+        classes: find( data, {kind: 'class'} ),
+        externals: find( data, {kind: 'external'} ),
+        events: find( data, {kind: 'event'} ),
+        globals: find(data, {
+            kind: ['member', 'function', 'constant', 'typedef'],
+            memberof: { isUndefined: true }
+        }),
+        mixins: find( data, {kind: 'mixin'} ),
+        modules: find( data, {kind: 'module'} ),
+        namespaces: find( data, {kind: 'namespace'} )
+    };
+
+    // functions that are also modules (as in "module.exports = function() {};") are not globals
+    members.globals = members.globals.filter(function(doclet) {
+        return !isModuleFunction(doclet);
+    });
+
+    return members;
+};
+
+/**
+ * Retrieve the member attributes for a doclet (for example, `virtual`, `static`, and
+ * `readonly`).
+ * @param {object} d The doclet whose attributes will be retrieved.
+ * @return {array<string>} The member attributes for the doclet.
+ */
+exports.getAttribs = function(d) {
+    var attribs = [];
+
+    if (d.virtual) {
+        attribs.push('abstract');
+    }
+
+    if (d.access && d.access !== 'public') {
+        attribs.push(d.access);
+    }
+
+    if (d.scope && d.scope !== 'instance' && d.scope !== 'global') {
+        if (d.kind === 'function' || d.kind === 'member' || d.kind === 'constant') {
+            attribs.push(d.scope);
+        }
+    }
+
+    if (d.readonly === true) {
+        if (d.kind === 'member') {
+            attribs.push('readonly');
+        }
+    }
+
+    if (d.kind === 'constant') {
+        attribs.push('constant');
+    }
+
+    if (d.nullable === true) {
+        attribs.push('nullable');
+    }
+    else if (d.nullable === false) {
+        attribs.push('non-null');
+    }
+
+    return attribs;
+};
+
+/**
+ * Retrieve links to allowed types for the member.
+ *
+ * @param {Object} d - The doclet whose types will be retrieved.
+ * @param {string} [cssClass] - The CSS class to include in the `class` attribute for each link.
+ * @return {Array.<string>} HTML links to allowed types for the member.
+ */
+exports.getSignatureTypes = function(d, cssClass) {
+    var types = [];
+
+    if (d.type && d.type.names) {
+        types = d.type.names;
+    }
+
+    if (types && types.length) {
+        types = types.map(function(t) {
+            return linkto(t, htmlsafe(t), cssClass);
+        });
+    }
+
+    return types;
+};
+
+/**
+ * Retrieve names of the parameters that the member accepts. If a value is provided for `optClass`,
+ * the names of optional parameters will be wrapped in a `<span>` tag with that class.
+ * @param {object} d The doclet whose parameter names will be retrieved.
+ * @param {string} [optClass] The class to assign to the `<span>` tag that is wrapped around the
+ * names of optional parameters. If a value is not provided, optional parameter names will not be
+ * wrapped with a `<span>` tag. Must be a legal value for a CSS class name.
+ * @return {array<string>} An array of parameter names, with or without `<span>` tags wrapping the
+ * names of optional parameters.
+ */
+exports.getSignatureParams = function(d, optClass) {
+    var pnames = [];
+
+    if (d.params) {
+        d.params.forEach(function(p) {
+            if (p.name && p.name.indexOf('.') === -1) {
+                if (p.optional && optClass) {
+                    pnames.push('<span class="' + optClass + '">' + p.name + '</span>');
+                }
+                else {
+                    pnames.push(p.name);
+                }
+            }
+        });
+    }
+
+    return pnames;
+};
+
+/**
+ * Retrieve links to types that the member can return.
+ *
+ * @param {Object} d - The doclet whose types will be retrieved.
+ * @param {string} [cssClass] - The CSS class to include in the `class` attribute for each link.
+ * @return {Array.<string>} HTML links to types that the member can return.
+ */
+exports.getSignatureReturns = function(d, cssClass) {
+    var returnTypes = [];
+
+    if (d.returns) {
+        d.returns.forEach(function(r) {
+            if (r && r.type && r.type.names) {
+                if (!returnTypes.length) {
+                    returnTypes = r.type.names;
+                }
+            }
+        });
+    }
+
+    if (returnTypes && returnTypes.length) {
+        returnTypes = returnTypes.map(function(r) {
+            return linkto(r, htmlsafe(r), cssClass);
+        });
+    }
+
+    return returnTypes;
+};
+
+/**
+ * Retrieve links to a member's ancestors.
+ *
+ * @param {TAFFY} data - The TaffyDB database to search.
+ * @param {Object} doclet - The doclet whose ancestors will be retrieved.
+ * @param {string} [cssClass] - The CSS class to include in the `class` attribute for each link.
+ * @return {Array.<string>} HTML links to a member's ancestors.
+ */
+exports.getAncestorLinks = function(data, doclet, cssClass) {
+    var ancestors = [],
+        doc = doclet.memberof;
+
+    while (doc) {
+        doc = find( data, {longname: doc}, false );
+        if (doc) { doc = doc[0]; }
+        if (!doc) { break; }
+        ancestors.unshift( linkto(doc.longname, (exports.scopeToPunc[doc.scope] || '') + doc.name,
+            cssClass) );
+        doc = doc.memberof;
+    }
+    if (ancestors.length) {
+        ancestors[ancestors.length - 1] += (exports.scopeToPunc[doclet.scope] || '');
+    }
+    return ancestors;
+};
+
+/**
+ * Iterates through all the doclets in `data`, ensuring that if a method
+ * @listens to an event, then that event has a 'listeners' array with the
+ * longname of the listener in it.
+ *
+ * @param {TAFFY} data - The TaffyDB database to search.
+ */
+exports.addEventListeners = function(data) {
+    // TODO: do this on the *pruned* data
+    // find all doclets that @listen to something.
+    var listeners = find(data, function () { return this.listens && this.listens.length; });
+
+    if (!listeners.length) {
+        return;
+    }
+
+    var doc,
+        l,
+        _events = {}; // just a cache to prevent me doing so many lookups
+
+    listeners.forEach(function (listener) {
+        l = listener.listens;
+        l.forEach(function (eventLongname) {
+            doc = _events[eventLongname] || find(data, {longname: eventLongname, kind: 'event'})[0];
+            if (doc) {
+                if (!doc.listeners) {
+                    doc.listeners = [listener.longname];
+                } else {
+                    doc.listeners.push(listener.longname);
+                }
+                _events[eventLongname] = _events[eventLongname] || doc;
+            }
+        });
+    });
+};
+
+/**
+ * Remove members that will not be included in the output, including:
+ *
+ * + Undocumented members.
+ * + Members tagged `@ignore`.
+ * + Members of anonymous classes.
+ * + Members tagged `@private`, unless the `private` option is enabled.
+ * @param {TAFFY} data The TaffyDB database to prune.
+ * @return {TAFFY} The pruned database.
+ */
+exports.prune = function(data) {
+    data({undocumented: true}).remove();
+    data({ignore: true}).remove();
+    if (!env.opts.private) { data({access: 'private'}).remove(); }
+    data({memberof: '<anonymous>'}).remove();
+
+    return data;
+};
+
+var registerLink = exports.registerLink = function(longname, url) {
+    linkMap.longnameToUrl[longname] = url;
+    linkMap.urlToLongname[url] = longname;
+};
+
+/**
+ * Get a longname's filename if one has been registered; otherwise, generate a unique filename, then
+ * register the filename.
+ * @private
+ */
+function getFilename(longname) {
+    var url;
+
+    if ( longnameToUrl[longname] && hasOwnProp.call(longnameToUrl, longname) ) {
+        url = longnameToUrl[longname];
+    } else {
+        url = getUniqueFilename(longname);
+        registerLink(longname, url);
+    }
+
+    return url;
+}
+
+/** Turn a doclet into a URL. */
+exports.createLink = function(doclet) {
+    var filename;
+    var fragment;
+    var match;
+    var fakeContainer;
+
+    var url = '';
+    var INSTANCE = exports.scopeToPunc.instance;
+    var longname = doclet.longname;
+
+    // handle doclets in which doclet.longname implies that the doclet gets its own HTML file, but
+    // doclet.kind says otherwise. this happens due to mistagged JSDoc (for example, a module that
+    // somehow has doclet.kind set to `member`).
+    // TODO: generate a warning (ideally during parsing!)
+    if (containers.indexOf(doclet.kind) === -1) {
+        match = /(\S+):/.exec(longname);
+        if (match && containers.indexOf(match[1]) !== -1) {
+            fakeContainer = match[1];
+        }
+    }
+
+    // the doclet gets its own HTML file
+    if ( containers.indexOf(doclet.kind) !== -1 || isModuleFunction(doclet) ) {
+        filename = getFilename(longname);
+    }
+    // mistagged version of a doclet that gets its own HTML file
+    else if ( containers.indexOf(doclet.kind) === -1 && fakeContainer ) {
+        filename = getFilename(doclet.memberof || longname);
+        if (doclet.name === doclet.longname) {
+            fragment = '';
+        }
+        else {
+            fragment = doclet.name || '';
+        }
+    }
+    // the doclet is within another HTML file
+    else {
+        filename = getFilename(doclet.memberof || exports.globalName);
+        fragment = getNamespace(doclet.kind) + (doclet.name || '');
+    }
+
+    url = fragment ? (filename + INSTANCE + fragment) : filename;
+
+    return url;
+};

--- a/templates/amddcl/tmpl/container.tmpl
+++ b/templates/amddcl/tmpl/container.tmpl
@@ -1,6 +1,7 @@
 <?js
     var self = this;
     docs.forEach(function(doc, i) {
+        doc.prefix = prefix;
 ?>
 
 <?js if (doc.kind === 'mainpage' || (doc.kind === 'package' && !doc.imported)) { ?>
@@ -27,6 +28,7 @@
 <article>
     <div class="container-overview">
     <?js if (doc.kind === 'module' && doc.module) { ?>
+        <?js doc.module.prefix = prefix; ?>
         <?js= self.partial('method.tmpl', doc.module) ?>
     <?js } ?>
 
@@ -41,6 +43,7 @@
 
         <?js if (doc.examples && doc.examples.length) { ?>
             <h3>Example<?js= doc.examples.length > 1? 's':'' ?></h3>
+            <?js doc.examples.prefix = prefix; ?>
             <?js= self.partial('examples.tmpl', doc.examples) ?>
         <?js } ?>
     <?js } ?>
@@ -51,7 +54,7 @@
         <h3 class="subsection-title">Extends</h3>
 
         <ul><?js augments.forEach(function(a) { ?>
-            <li><?js= self.linkto(a, a) ?></li>
+            <li><?js= self.linkto(a, a, undefined, undefined, prefix) ?></li>
         <?js }); ?></ul>
     <?js } ?>
 
@@ -59,7 +62,7 @@
         <h3 class="subsection-title">Mixes In</h3>
 
         <ul><?js doc.mixes.forEach(function(a) { ?>
-            <li><?js= self.linkto(a, a) ?></li>
+            <li><?js= self.linkto(a, a, undefined, undefined, prefix) ?></li>
         <?js }); ?></ul>
     <?js } ?>
 
@@ -67,7 +70,7 @@
         <h3 class="subsection-title">Requires</h3>
 
         <ul><?js doc.requires.forEach(function(r) { ?>
-            <li><?js= self.linkto(r, r) ?></li>
+            <li><?js= self.linkto(r, r, undefined, undefined, prefix) ?></li>
         <?js }); ?></ul>
     <?js } ?>
 
@@ -78,7 +81,7 @@
         <h3 class="subsection-title">Classes</h3>
 
         <dl><?js classes.forEach(function(c) { ?>
-            <dt><?js= self.linkto(c.longname, c.name) ?></dt>
+            <dt><?js= self.linkto(c.longname, c.name, undefined, undefined, prefix) ?></dt>
             <dd><?js if (c.summary) { ?><?js= c.summary ?><?js } ?></dd>
         <?js }); ?></dl>
     <?js } ?>
@@ -90,7 +93,7 @@
         <h3 class="subsection-title">Namespaces</h3>
 
         <dl><?js namespaces.forEach(function(n) { ?>
-            <dt><a href="namespaces.html#<?js= n.longname ?>"><?js= self.linkto(n.longname, n.name) ?></a></dt>
+            <dt><a href="namespaces.html#<?js= n.longname ?>"><?js= self.linkto(n.longname, n.name, undefined, undefined, prefix) ?></a></dt>
             <dd><?js if (n.summary) { ?><?js= n.summary ?><?js } ?></dd>
         <?js }); ?></dl>
     <?js } ?>
@@ -104,6 +107,7 @@
         <h3 class="subsection-title">Members</h3>
 
         <dl><?js members.forEach(function(p) { ?>
+            <?js p.prefix = prefix; ?>
             <?js= self.partial('members.tmpl', p) ?>
         <?js }); ?></dl>
     <?js } ?>
@@ -115,6 +119,7 @@
         <h3 class="subsection-title">Methods</h3>
 
         <dl><?js methods.forEach(function(m) { ?>
+            <?js m.prefix = prefix; ?>
             <?js= self.partial('method.tmpl', m) ?>
         <?js }); ?></dl>
     <?js } ?>
@@ -126,6 +131,7 @@
         <h3 class="subsection-title">Type Definitions</h3>
 
         <dl><?js typedefs.forEach(function(e) {
+                e.prefix = prefix;
                 if (e.signature) {
             ?>
                 <?js= self.partial('method.tmpl', e) ?>
@@ -146,6 +152,7 @@
         <h3 class="subsection-title">Events</h3>
 
         <dl><?js events.forEach(function(e) { ?>
+            <?js e.prefix = prefix; ?>
             <?js= self.partial('method.tmpl', e) ?>
         <?js }); ?></dl>
     <?js } ?>

--- a/templates/amddcl/tmpl/details.tmpl
+++ b/templates/amddcl/tmpl/details.tmpl
@@ -34,7 +34,7 @@ if (data.defaultvalue && data.defaultvaluetype === 'object') {
     <?js if (data.inherited && data.inherits) { ?>
     <dt class="inherited-from">Inherited From:</dt>
     <dd class="inherited-from"><ul class="dummy"><li>
-        <?js= this.linkto(data.inherits, this.htmlsafe(data.inherits)) ?>
+        <?js= this.linkto(data.inherits, this.htmlsafe(data.inherits), undefined, undefined, data.prefix) ?>
     </li></dd>
     <?js } ?>
 
@@ -74,7 +74,7 @@ if (data.defaultvalue && data.defaultvaluetype === 'object') {
     <?js if (data.meta && data.kind !== 'module' && self.outputSourceFiles) {?>
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <?js= self.linkto(meta.shortpath) ?>, <?js= self.linkto(meta.shortpath, 'line ' + meta.lineno, null, 'line' + meta.lineno) ?>
+        <?js= self.linkto(meta.shortpath, undefined, undefined, undefined, data.prefix) ?>, <?js= self.linkto(meta.shortpath, 'line ' + meta.lineno, null, 'line' + meta.lineno, data.prefix) ?>
     </li></ul></dd>
     <?js } ?>
 
@@ -91,7 +91,7 @@ if (data.defaultvalue && data.defaultvaluetype === 'object') {
     <dt class="tag-see">See:</dt>
     <dd class="tag-see">
         <ul><?js see.forEach(function(s) { ?>
-            <li><?js= self.linkto(s) ?></li>
+            <li><?js= self.linkto(s, undefined, undefined, undefined, data.prefix) ?></li>
         <?js }); ?></ul>
     </dd>
     <?js } ?>

--- a/templates/amddcl/tmpl/layout.tmpl
+++ b/templates/amddcl/tmpl/layout.tmpl
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <title>JSDoc: <?js= title ?></title>
 
-    <script src="scripts/prettify/prettify.js"> </script>
-    <script src="scripts/prettify/lang-css.js"> </script>
+    <script src="<?js= prefix ?>scripts/prettify/prettify.js"> </script>
+    <script src="<?js= prefix ?>scripts/prettify/lang-css.js"> </script>
     <style>
         [inherited] {
             display: none;
@@ -37,7 +37,10 @@
             if (event.type !== "DOMContentLoaded") {
                 event.target.innerHTML = (shouldShow ? "Hide" : "Show") + " inherited";
             } else if (!document.querySelector("[inherited]")) {
-                document.getElementById("toggleinherited").style.display = "none";
+                var toggleLink = document.getElementById("toggleinherited");
+                if (toggleLink) {
+                    toggleLink.style.display = "none";
+                }
             }
         }
         window.addEventListener("DOMContentLoaded", toggleInherited);
@@ -45,8 +48,8 @@
     <!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
-    <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+    <link type="text/css" rel="stylesheet" href="<?js= prefix ?>styles/prettify-tomorrow.css">
+    <link type="text/css" rel="stylesheet" href="<?js= prefix ?>styles/jsdoc-default.css">
 </head>
 
 <body>
@@ -59,7 +62,7 @@
 </div>
 
 <nav>
-    <?js= this.nav ?>
+    <?js= this.nav.replace(/\$prefix/g, prefix) ?>
 </nav>
 
 <br clear="both">
@@ -69,6 +72,6 @@
 </footer>
 
 <script> prettyPrint(); </script>
-<script src="scripts/linenumber.js"> </script>
+<script src="<?js= prefix ?>scripts/linenumber.js"> </script>
 </body>
 </html>

--- a/templates/amddcl/tmpl/members.tmpl
+++ b/templates/amddcl/tmpl/members.tmpl
@@ -30,7 +30,7 @@ var self = this;
     <?js if (data.fires && fires.length) { ?>
         <h5>Fires:</h5>
         <ul><?js fires.forEach(function(f) { ?>
-            <li><?js= self.linkto(f) ?></li>
+            <li><?js= self.linkto(f, undefined, undefined, undefined, data.prefix) ?></li>
         <?js }); ?></ul>
     <?js } ?>
 

--- a/templates/amddcl/tmpl/method.tmpl
+++ b/templates/amddcl/tmpl/method.tmpl
@@ -30,7 +30,7 @@ var self = this;
 
     <?js if (data['this']) { ?>
         <h5>This:</h5>
-        <ul><li><?js= this.linkto(data['this'], data['this']) ?></li></ul>
+        <ul><li><?js= this.linkto(data['this'], data['this'], undefined, undefined, data.prefix) ?></li></ul>
     <?js } ?>
 
     <?js if (data.params && params.length) { ?>
@@ -43,28 +43,28 @@ var self = this;
     <?js if (data.requires && data.requires.length) { ?>
     <h5>Requires:</h5>
     <ul><?js data.requires.forEach(function(r) { ?>
-        <li><?js= self.linkto(r) ?></li>
+        <li><?js= self.linkto(r, undefined, undefined, undefined, data.prefix) ?></li>
     <?js }); ?></ul>
     <?js } ?>
 
     <?js if (data.fires && fires.length) { ?>
     <h5>Fires:</h5>
     <ul><?js fires.forEach(function(f) { ?>
-        <li><?js= self.linkto(f) ?></li>
+        <li><?js= self.linkto(f, undefined, undefined, undefined, data.prefix) ?></li>
     <?js }); ?></ul>
     <?js } ?>
 
     <?js if (data.listens && listens.length) { ?>
     <h5>Listens to Events:</h5>
     <ul><?js listens.forEach(function(f) { ?>
-        <li><?js= self.linkto(f) ?></li>
+        <li><?js= self.linkto(f, undefined, undefined, undefined, data.prefix) ?></li>
     <?js }); ?></ul>
     <?js } ?>
 
     <?js if (data.listeners && listeners.length) { ?>
     <h5>Listeners of This Event:</h5>
     <ul><?js listeners.forEach(function(f) { ?>
-        <li><?js= self.linkto(f) ?></li>
+        <li><?js= self.linkto(f, undefined, undefined, undefined, data.prefix) ?></li>
     <?js }); ?></ul>
     <?js } ?>
 

--- a/templates/amddcl/tmpl/type.tmpl
+++ b/templates/amddcl/tmpl/type.tmpl
@@ -2,6 +2,6 @@
     var data = obj;
     var self = this;
     data.forEach(function(name, i) { ?>
-<span class="param-type"><?js= self.linkto(name, self.htmlsafe(name)) ?></span>
+<span class="param-type"><?js= self.linkto(name, self.htmlsafe(name), undefined, undefined, data.prefix) ?></span>
 <?js if (i < data.length-1) { ?>|<?js } ?>
 <?js }); ?>


### PR DESCRIPTION
And introduced new Grunt task option, `paths`, which lets you specify the location of modules with specified namespace as a relative path from JSDoc documents root (e.g. ../../sampleframework/0.1.0-dev/sampleframework from /path/to/jsdoc-amddcl/out/sampleproject/0.1.0-dev/).
