### PR TITLE
Add new config param includeEventsInToc allowing to avoid duplicate events in TOC (refs #41)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,7 +86,8 @@ module.exports = function (grunt) {
 						imports: [
 							"./out/sampleproject"
 						],
-						packagePathFormat: "${name}/docs/api/${version}"
+						packagePathFormat: "${name}/docs/api/${version}",
+						includeEventsInTOC: "false"
 					},
 					{
 						args: [

--- a/sampleprojects/sampleframework/Base0.js
+++ b/sampleprojects/sampleframework/Base0.js
@@ -1,6 +1,14 @@
 /** @module sampleframework/Base0 */
 define(["dcl/dcl"], function (dcl) {
 	/**
+	 * Foo event. Dispached in some conditions.
+	 * @event module:sampleframework/Base0#event-foo
+	 * @property {number} value1 - First value.
+	 * @property {number} value2- Second value.
+	 */
+	
+	
+	/**
 	 * A sample base widget class.
 	 * @class module:sampleframework/Base0
 	 */
@@ -38,6 +46,14 @@ define(["dcl/dcl"], function (dcl) {
 		 */
 		methodOfBase0: function () {
 			console.log("module:sampleframework/Base0#methodOfBase0 called.");
+		},
+		
+		/**
+		 * Description of emitFooEvent.
+		 * @fires module:sampleframework/Base0#event-foo
+		 */
+		emitFooEvent: function () {
+			// Some code that emits the event-foo event.
 		}
 	});
 	

--- a/sampleprojects/sampleframework/SubclassOfBase0.js
+++ b/sampleprojects/sampleframework/SubclassOfBase0.js
@@ -1,0 +1,14 @@
+/** @module sampleframework/SubclassOfBase0 */
+define([
+	"dcl/dcl",
+	"./Base0",
+	"./Base1"
+], function (dcl, Base0) {
+	/**
+	 * Sample widget class.
+	 * @class module:sampleframework/SubclassOfBase0
+	 * @augments {module:sampleframework/Base0}
+	 */
+	return dcl([Base0], /** @lends module:sampleframework/SubclassOfBase0# */ {
+	});
+});

--- a/sampleprojects/sampleprojectchild/Base0.js
+++ b/sampleprojects/sampleprojectchild/Base0.js
@@ -1,6 +1,13 @@
 /** @module sampleprojectchild/Base0 */
 define(["dcl/dcl"], function (dcl) {
 	/**
+	 * Foo-child event. Dispached in some conditions.
+	 * @event module:sampleprojectchild/Base0#event-foo-child
+	 * @property {number} value1 - First value.
+	 * @property {number} value2- Second value.
+	 */
+	
+	/**
 	 * A sample base widget class.
 	 * @class module:sampleprojectchild/Base0
 	 */
@@ -25,6 +32,14 @@ define(["dcl/dcl"], function (dcl) {
 		 */
 		methodOfBase0: function () {
 			console.log("module:sampleprojectchild/Base0#methodOfBase0 called.");
+		},
+		
+		/**
+		 * Description of emitFooChildEvent.
+		 * @fires module:sampleframework/Base0#event-foo-child
+		 */
+		emitFooChildEvent: function () {
+			// Some code that emits the event-foo-child event.
 		}
 	});
 });

--- a/tasks/jsdoc.js
+++ b/tasks/jsdoc.js
@@ -19,6 +19,9 @@ module.exports = function (grunt) {
 			if (file.packagePathFormat) {
 				process.env.JSDOC_PACKAGE_PATH_FORMAT = file.packagePathFormat;
 			}
+			if (file.includeEventsInTOC) {
+				process.env.INCLUDE_EVENTS_IN_TOC = file.includeEventsInTOC;
+			}
 			var args = [
 				JSON.stringify(path.resolve(path.dirname(module.filename), "../node_modules/jsdoc/jsdoc.js")),
 				"-c",

--- a/templates/amddcl/publish.js
+++ b/templates/amddcl/publish.js
@@ -260,18 +260,21 @@ function buildNav(members) {
         }
     }
 
-    if (members.events.filter(function(e) {
-        return !hasOwnProp.call(seen, e.longname) && !e.imported;
-    }).length) {
-        nav += '<h3>Events</h3><ul>';
-        members.events.forEach(function(e) {
-            if ( !hasOwnProp.call(seen, e.longname) && !e.imported ) {
-                nav += '<li>'+linkto(e.longname, e.name, undefined, undefined, '$prefix')+'</li>';
-            }
-            seen[e.longname] = true;
-        });
 
-        nav += '</ul>';
+    if (process.env.INCLUDE_EVENTS_IN_TOC !== 'false') {
+        if (members.events.filter(function(e) {
+            return !hasOwnProp.call(seen, e.longname) && !e.imported;
+        }).length) {
+            nav += '<h3>Events</h3><ul>';
+            members.events.forEach(function(e) {
+                if ( !hasOwnProp.call(seen, e.longname) && !e.imported ) {
+                    nav += '<li>'+linkto(e.longname, e.name, undefined, undefined, '$prefix')+'</li>';
+                }
+                seen[e.longname] = true;
+            });
+
+            nav += '</ul>';
+        }
     }
 
     if (members.namespaces.filter(function(n) {


### PR DESCRIPTION
- Adds a new configuration parameter `ìncludeEventsInTOC` allowing a project to opt-out from the inclusion of a Events section in the TOC of the doc.
- Adds event declaration (`@event` and `@fires`) to check the output:
  - In sampleprojects/sampleframework, an event is added on Base0 and is inherited by SubclassOfBase0. This project does not set the `includeEventsInTOC` flag, thus it gets duplicated events in the TOC.
  - In sampleprojects/sampleprojectchild, an event is added on Base0 and is inherited by SubclassOfBase0. This project sets the `includeEventsInTOC` flag to false, thus the Events section is absent from the TOC.
