### PR TITLE
complete the fix for #18

### DIFF
--- a/templates/amddcl/static/styles/jsdoc-default.css
+++ b/templates/amddcl/static/styles/jsdoc-default.css
@@ -51,7 +51,7 @@ section
     background-color: #fff;
     padding: 12px 24px;
     border-bottom: 1px solid #ccc;
-    margin-right: 240px;
+    margin-right: 280px;
 }
 
 .variation {


### PR DESCRIPTION
Since the navigator was widen in https://github.com/ibm-js/jsdoc-amddcl/commit/c41845d14b38cf754724483216c36ecb909d6c19, the section needs to be shrinked.

This solves the overlaping between section and navigator in http://ibm-js.github.io/deliteful/docs/api/0.4.0/deliteful/ComboBox.html for example.
