### PR TITLE
automatically download prettify files

### DIFF
--- a/installPrettify.js
+++ b/installPrettify.js
@@ -1,0 +1,40 @@
+var request = require("https").request;
+var fs = require("fs");
+
+function getOptions(file) {
+	return {
+		hostname: "google-code-prettify.googlecode.com",
+		path: "/svn/branches/release-4-Mar-2013/src/" + file,
+		method: "GET",
+		headers: {
+			"user-agent": "nodejs"
+		}
+	};
+}
+
+var files = ["prettify.js", "lang-css.js"];
+var dest = __dirname + "/templates/amddcl/static/scripts/prettify/";
+
+fs.mkdirSync(dest);
+
+files.forEach(function (file) {
+	request(getOptions(file), function (res) {
+		var statusCode = res.statusCode;
+		if (statusCode === 404) {
+			console.error("File " + file + " not found.");
+		} else if (statusCode === 200) {
+			var data = "";
+			res.on("data", function (chunk) {
+				data += chunk.toString();
+			});
+
+			res.on("end", function () {
+				fs.writeFileSync(dest + file, data);
+			});
+		} else {
+			console.error(file + ": " + "HTTP GET Error " + statusCode);
+		}
+	}).on("error", function (e) {
+		console.error(e);
+	}).end();
+});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
 		"taffydb": "https://github.com/hegemonic/taffydb/tarball/master",
 		"catharsis": "~0.7.1"
 	},
+	"scripts": {
+		"postinstall": "node installPrettify.js"
+	},
 	"devDependencies": {
 		"grunt": "~0.4.0"
 	},


### PR DESCRIPTION
This would remove the need to manually install the prettify files.

In https://github.com/ibm-js/jsdoc-amddcl/issues/40 @cjolif suggested to use grunt to do that but I think using the npm postinstall hook is more adapted to solve this issue.
